### PR TITLE
feat: added calc command #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "piscine-4-discordbot",
-  "version": "0.0.1",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "piscine-4-discordbot",
-      "version": "0.0.1",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.0",
+        "a-calc": "^1.3.12",
         "axios": "^1.6.8",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.5",
@@ -17,6 +18,7 @@
         "night-api": "^1.3.0"
       },
       "devDependencies": {
+        "prettier": "3.2.5",
         "tsup": "^8.0.2",
         "tsx": "^4.8.2",
         "typescript": "^5.4.5"
@@ -878,6 +880,14 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/a-calc": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/a-calc/-/a-calc-1.3.12.tgz",
+      "integrity": "sha512-kfZ0Sfnte8Zm5WjIQzlslkDlAP6Kppqyhfmxk/XQVymU78vnrqhRLVFGS40yU4z2DiGb42XTgCxc/fDZe9Bgew==",
+      "dependencies": {
+        "typescript-treasure": "0.0.9"
       }
     },
     "node_modules/ansi-regex": {
@@ -1854,6 +1864,21 @@
         }
       }
     },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -2714,6 +2739,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-treasure": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/typescript-treasure/-/typescript-treasure-0.0.9.tgz",
+      "integrity": "sha512-QPmpqJvQqZ7rt2iVNzPrtQNSFs1zVuTuP+jzE3np7qytEUcfSKtAW8RTDslldeAwaJjVJa0UM3ps1uVddpEMqQ=="
     },
     "node_modules/undici": {
       "version": "5.27.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/42-Piscine-Batch-4/discordbot#readme",
   "dependencies": {
     "@types/lodash": "^4.17.0",
+    "a-calc": "^1.3.12",
     "axios": "^1.6.8",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5",

--- a/src/commands/calc.ts
+++ b/src/commands/calc.ts
@@ -1,0 +1,36 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { calc } from 'a-calc';
+
+const calculate = (expression: string): number | string => {
+  try {
+    return calc(expression);
+  } catch (error) {
+    throw new Error("Invalid expression format.")
+  }
+};
+
+export const data = new SlashCommandBuilder()
+  .setName("calc")
+  .setDescription("Perform a simple arithmetic calculation")
+  .addStringOption((option) =>
+    option
+      .setName("expression")
+      .setDescription("The mathematical expression to calculate")
+      .setRequired(true)
+  );
+
+export const execute = async (interaction: ChatInputCommandInteraction) => {
+  const expression = interaction.options.getString("expression", true);
+  try {
+    const result = calculate(expression);
+    await interaction.reply(
+      `Expression: \\\`${expression}\\\`\nResult: \\\`${result}\\\``
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      await interaction.reply(`Error: ${error.message}`);
+    } else {
+      await interaction.reply("An unknown error occurred.");
+    }
+  }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -30,6 +30,9 @@ import * as dice from "./dice";
 // Import the "shout" command
 import * as shout from "./shout";
 
+// Import the "calc" command
+import * as calc from "./calc"; 
+
 /**
  * Object containing all available commands.
  * Each property corresponds to a command module.
@@ -44,4 +47,5 @@ export const commands = {
   ten_queens,
   dice,
   shout,
+  calc,
 };


### PR DESCRIPTION
Features:
1. **Calculator Command**: A new slash command `/calc` has been added to the bot. Users can invoke this command with a mathematical expression as an argument, and the bot will respond with the calculated result.

2. **Expression Evaluation**: The `a-calc` package is used to evaluate the user-provided expression. This package supports a wide range of arithmetic operations, functions, and constants, ensuring robust and accurate calculations.

3. **Error Handling**: If the provided expression is invalid or an error occurs during the calculation, the bot will respond with an appropriate error message.


Implementation Details:
- A new file `calc.ts` has been added to the project, which contains the implementation of the calculator command.
- The `calculate` function is a helper function that wraps the `calc` function from `a-calc` and handles any exceptions that may occur during the calculation.

Testing:
The calculator command has been manually tested with various expressions, including:

- Basic arithmetic operations (addition, subtraction, multiplication, division)
- Exponents and parentheses for order of operations

PS: Tried to write it without using lib, not able to fix parentheses etc "(" & ")"