### PR TITLE
feat: added celsius command #62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "piscine-4-discordbot",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "piscine-4-discordbot",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piscine-4-discordbot",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "More description to come!",
   "main": "src/index.ts",
   "scripts": {

--- a/src/commands/bedtime.ts
+++ b/src/commands/bedtime.ts
@@ -11,25 +11,29 @@ export const data = new SlashCommandBuilder()
  * @param {CommandInteraction} interaction - The interaction event triggered by the command.
  */
 export const execute = async (interaction: CommandInteraction) => {
-  const currentTime = new Date();
+  const currentTime = new Date()
 
   const bedTime = new Date(
     currentTime.getFullYear(),
     currentTime.getMonth(),
     currentTime.getDate(),
-    23, 42, 0
-  );
+    23,
+    42,
+    0
+  )
 
   const wakeTime = new Date(
     currentTime.getFullYear(),
     currentTime.getMonth(),
     currentTime.getDate(),
-    7, 42, 0
-  );
+    7,
+    42,
+    0
+  )
 
   if (currentTime < bedTime && currentTime > wakeTime) {
-    interaction.reply(`It's still too early for bed!`);
+    interaction.reply(`It's still too early for bed!`)
   } else {
-    interaction.reply(`It's past 11.42pm, time to sleep.`);
+    interaction.reply(`It's past 11.42pm, time to sleep.`)
   }
 }

--- a/src/commands/caesar.ts
+++ b/src/commands/caesar.ts
@@ -31,8 +31,8 @@ const cipherConvert = (char: string, cchar: number, cnum: number): number => {
 export const execute = async (interaction: ChatInputCommandInteraction) => {
   const message = interaction.options.getString("message", true)
   const cipher = interaction.options.getNumber("cipher") ?? 0
-  const cchar = (26 + cipher % 26) % 26
-  const cnum = (10 + cipher % 10) % 10
+  const cchar = (26 + (cipher % 26)) % 26
+  const cnum = (10 + (cipher % 10)) % 10
   const output = Array.from(message)
     .map((c) => String.fromCharCode(cipherConvert(c, cchar, cnum)))
     .join("")

--- a/src/commands/celsius.ts
+++ b/src/commands/celsius.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js"
 
 export const data = new SlashCommandBuilder()
   .setName("temperature")
@@ -12,7 +12,9 @@ export const data = new SlashCommandBuilder()
   .addStringOption((option) =>
     option
       .setName("from-scale")
-      .setDescription("Original temperature scale (Celsius, Kelvin or Fahrenheit)")
+      .setDescription(
+        "Original temperature scale (Celsius, Kelvin or Fahrenheit)"
+      )
       .setRequired(true)
       .addChoices(
         { name: "Celsius", value: "Celsius" },
@@ -23,27 +25,31 @@ export const data = new SlashCommandBuilder()
   .addStringOption((option) =>
     option
       .setName("to-scale")
-      .setDescription("Target temperature scale (Celsius, Kelvin or Fahrenheit)")
+      .setDescription(
+        "Target temperature scale (Celsius, Kelvin or Fahrenheit)"
+      )
       .setRequired(true)
       .addChoices(
         { name: "Celsius", value: "Celsius" },
         { name: "Kelvin", value: "Kelvin" },
         { name: "Fahrenheit", value: "Fahrenheit" }
       )
-  );
+  )
 
 export const execute = async (interaction: ChatInputCommandInteraction) => {
-  const temperature = interaction.options.getNumber("temperature", true);
-  const fromScale = interaction.options.getString("from-scale", true);
-  const toScale = interaction.options.getString("to-scale", true);
+  const temperature = interaction.options.getNumber("temperature", true)
+  const fromScale = interaction.options.getString("from-scale", true)
+  const toScale = interaction.options.getString("to-scale", true)
 
   if (
     fromScale.toLowerCase() !== "celsius" &&
     fromScale.toLowerCase() !== "kelvin" &&
     fromScale.toLowerCase() !== "fahrenheit"
   ) {
-    await interaction.reply("Invalid original temperature scale. Choose Celsius, Kelvin or Fahrenheit.");
-    return;
+    await interaction.reply(
+      "Invalid original temperature scale. Choose Celsius, Kelvin or Fahrenheit."
+    )
+    return
   }
 
   if (
@@ -51,36 +57,44 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
     toScale.toLowerCase() !== "kelvin" &&
     toScale.toLowerCase() !== "fahrenheit"
   ) {
-    await interaction.reply("Invalid target temperature scale. Choose Celsius, Kelvin or Fahrenheit.");
-    return;
+    await interaction.reply(
+      "Invalid target temperature scale. Choose Celsius, Kelvin or Fahrenheit."
+    )
+    return
   }
 
-  const convertedTemp = convertTemperature(temperature, fromScale, toScale);
-  await interaction.reply(`${temperature.toFixed(2)}°${fromScale} is equal to ${convertedTemp.toFixed(2)}°${toScale}`);
-};
+  const convertedTemp = convertTemperature(temperature, fromScale, toScale)
+  await interaction.reply(
+    `${temperature.toFixed(2)}°${fromScale} is equal to ${convertedTemp.toFixed(2)}°${toScale}`
+  )
+}
 
-const convertTemperature = (temp: number, fromScale: string, toScale: string): number => {
-    const celsiusTemp = (() => {
-      switch (fromScale.toLowerCase()) {
-        case "celsius":
-          return temp;
-        case "kelvin":
-          return temp - 273.15;
-        case "fahrenheit":
-          return (temp - 32) * (5 / 9);
-        default:
-          throw new Error("Invalid temperature scale.");
-      }
-    })();
-  
-    switch (toScale.toLowerCase()) {
+const convertTemperature = (
+  temp: number,
+  fromScale: string,
+  toScale: string
+): number => {
+  const celsiusTemp = (() => {
+    switch (fromScale.toLowerCase()) {
       case "celsius":
-        return celsiusTemp;
+        return temp
       case "kelvin":
-        return celsiusTemp + 273.15;
+        return temp - 273.15
       case "fahrenheit":
-        return celsiusTemp * (9 / 5) + 32;
+        return (temp - 32) * (5 / 9)
       default:
-        throw new Error("Invalid temperature scale.");
+        throw new Error("Invalid temperature scale.")
     }
-  };
+  })()
+
+  switch (toScale.toLowerCase()) {
+    case "celsius":
+      return celsiusTemp
+    case "kelvin":
+      return celsiusTemp + 273.15
+    case "fahrenheit":
+      return celsiusTemp * (9 / 5) + 32
+    default:
+      throw new Error("Invalid temperature scale.")
+  }
+}

--- a/src/commands/celsius.ts
+++ b/src/commands/celsius.ts
@@ -1,0 +1,73 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+
+export const data = new SlashCommandBuilder()
+  .setName("celsius")
+  .setDescription("Convert temperature to or from Celsius")
+  .addIntegerOption((option) =>
+    option
+      .setName("temperature-integer")
+      .setDescription("Integer part of the temperature value")
+      .setRequired(true)
+  )
+  .addIntegerOption((option) =>
+    option
+      .setName("temperature-decimal")
+      .setDescription("Decimal part of the temperature value")
+      .setRequired(true)
+  )
+  .addStringOption((option) =>
+    option
+      .setName("from-scale")
+      .setDescription("Original temperature scale (Kelvin or Fahrenheit)")
+      .setRequired(true)
+      .addChoices(
+        { name: "Kelvin", value: "Kelvin" },
+        { name: "Fahrenheit", value: "Fahrenheit" }
+      )
+  )
+  .addBooleanOption((option) =>
+    option
+      .setName("reverse")
+      .setDescription(
+        "Reverse the conversion (from Celsius instead of to Celsius)"
+      )
+  );
+
+export const execute = async (interaction: ChatInputCommandInteraction) => {
+  const temperatureInteger = interaction.options.getInteger("temperature-integer", true);
+  const temperatureDecimal = interaction.options.getInteger("temperature-decimal", true);
+  const temperature = parseFloat(`${temperatureInteger}.${temperatureDecimal.toFixed(2)}`);
+  const fromScale = interaction.options.getString("from-scale", true);
+  const reverse = interaction.options.getBoolean("reverse") || false;
+
+  if (fromScale.toLowerCase() !== "kelvin" && fromScale.toLowerCase() !== "fahrenheit") {
+    await interaction.reply("Invalid temperature scale. Choose either Kelvin or Fahrenheit.");
+    return;
+  }
+
+  const convertedTemp = convertTemperature(temperature, fromScale, "Celsius", reverse);
+
+  if (reverse) {
+    await interaction.reply(`${temperature.toFixed(2)}°Celsius is equal to ${convertedTemp.toFixed(2)}°${fromScale}`);
+  } else {
+    await interaction.reply(`${temperature.toFixed(2)}°${fromScale} is equal to ${convertedTemp.toFixed(2)}°Celsius`);
+  }
+};
+
+function convertTemperature(temp: number, fromScale: string, toScale: string, reverse: boolean = false): number {
+  if (fromScale === "Kelvin") {
+    if (reverse) {
+      return temp + 273.15;
+    } else {
+      return temp - 273.15;
+    }
+  } else if (fromScale === "Fahrenheit") {
+    if (reverse) {
+      return (temp * 9 / 5) + 32; 
+    } else {
+      return (temp - 32) * 5 / 9;
+    }
+  } else {
+    return temp;
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,6 +5,7 @@
  * It exports an object containing all available commands, allowing easy access to each command module.
  */
 
+import * as celsius from "./celsius"
 import * as avatar from "./avatar"
 import * as calc from "./calc"
 import * as dice from "./dice"
@@ -47,4 +48,5 @@ export const commands = {
   avatar,
   palindrome,
   last,
+  celsius,
 }

--- a/src/commands/member_count.ts
+++ b/src/commands/member_count.ts
@@ -1,23 +1,23 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js"
 
 export const data = new SlashCommandBuilder()
-    .setName("member_count")
-    .setDescription("Get detailed information about the server members");
+  .setName("member_count")
+  .setDescription("Get detailed information about the server members")
 
 export const execute = async (interaction: ChatInputCommandInteraction) => {
-    const guild = interaction.guild;
+  const guild = interaction.guild
 
-    if (!guild) {
-        await interaction.reply("This command can only be used in a server.");
-        return;
-    }
+  if (!guild) {
+    await interaction.reply("This command can only be used in a server.")
+    return
+  }
 
-    const memberCount = guild.memberCount;
-    const memberCountMessage = `
+  const memberCount = guild.memberCount
+  const memberCountMessage = `
     **Server Member Count:** 
     
     Total Members: ${memberCount} 
-    `;
+    `
 
-    await interaction.reply(memberCountMessage);
-};
+  await interaction.reply(memberCountMessage)
+}


### PR DESCRIPTION
Features:

- Temperature Conversion Command: Added a new slash command named `/temperature`.
- Flexible Temperature Scales: Users can convert between Celsius, Kelvin, and Fahrenheit scales.
- Intuitive Options: The command includes options for specifying the temperature value, original scale, and target scale.
- Error Handling: Validation is in place to ensure that only valid temperature scales are accepted.

Testing:

- Testing has been performed to ensure accurate temperature conversions between all supported scales.
- Edge cases, such as invalid input values and temperature scales, have been thoroughly tested.

Future Improvements:

- Add support for additional temperature scales (e.g., Réaumur, Rankine).
- Implement an option to display the conversion formula used for each calculation.
- Allow users to specify alternative unit symbols (e.g., °C, K, °F) for better readability.
- Provide the ability to convert multiple temperature values at once.
