### PR TITLE
chore: update discord.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "piscine-4-discordbot",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.0",
         "a-calc": "^1.3.12",
         "axios": "^1.6.8",
-        "discord.js": "^14.14.1",
+        "discord.js": "^14.15.2",
         "dotenv": "^16.4.5",
         "lodash": "^4.17.21",
         "night-api": "^1.3.0"
@@ -26,16 +26,16 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
-      "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.1.tgz",
+      "integrity": "sha512-GkF+HM01FHy+NSoTaUPR8z44otfQgJ1AIsRxclYGUZDyUbdZEFyD/5QVv2Y1Flx6M+B0bQLzg2M9CJv5lGTqpA==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.3",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/shapeshift": "^3.9.3",
-        "discord-api-types": "0.37.61",
+        "@discordjs/formatters": "^0.4.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/shapeshift": "^3.9.7",
+        "discord-api-types": "0.37.83",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
+        "ts-mixer": "^6.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -51,74 +51,74 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
-      "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0.tgz",
+      "integrity": "sha512-fJ06TLC1NiruF35470q3Nr1bi95BdvKFAF+T5bNfZJ4bNdqZ3VZ+Ttg6SThqTxm6qumSG3choxLBHMC69WXNXQ==",
       "dependencies": {
-        "discord-api-types": "0.37.61"
+        "discord-api-types": "0.37.83"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
-      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
+      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61",
-        "magic-bytes.js": "^1.5.0",
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.2",
-        "undici": "5.27.2"
+        "undici": "6.13.0"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
-      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0.tgz",
+      "integrity": "sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
-      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0.tgz",
+      "integrity": "sha512-IndcI5hzlNZ7GS96RV3Xw1R2kaDuXEp7tRIy/KlhidpN/BQ1qh1NZt3377dMLTa44xDUNKT7hnXkA/oUAzD/lg==",
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
-      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0.tgz",
+      "integrity": "sha512-O97DIeSvfNTn5wz5vaER6ciyUsr7nOqSEtsLoMhhIgeFkhnxLRqSr00/Fpq2/ppLgjDGLbQCDzIK7ilGoB/M7A==",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
-        "@discordjs/rest": "^2.1.0",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.9",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61",
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
         "tslib": "^2.6.2",
-        "ws": "^8.14.2"
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
-      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0.tgz",
+      "integrity": "sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==",
       "engines": {
         "node": ">=18"
       }
@@ -137,14 +137,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -292,9 +284,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -312,17 +304,17 @@
       "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.12.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
+      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
-      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -588,29 +580,27 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.61",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
-      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
     },
     "node_modules/discord.js": {
-      "version": "14.14.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
-      "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
+      "version": "14.15.2",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.2.tgz",
+      "integrity": "sha512-wGD37YCaTUNprtpqMIRuNiswwsvSWXrHykBSm2SAosoTYut0VUDj9yo9t4iLtMKvuhI49zYkvKc2TNdzdvpJhg==",
       "dependencies": {
-        "@discordjs/builders": "^1.7.0",
+        "@discordjs/builders": "^1.8.1",
         "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.3.3",
-        "@discordjs/rest": "^2.1.0",
-        "@discordjs/util": "^1.0.2",
-        "@discordjs/ws": "^1.0.2",
-        "@sapphire/snowflake": "3.5.1",
-        "@types/ws": "8.5.9",
-        "discord-api-types": "0.37.61",
+        "@discordjs/formatters": "^0.4.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@discordjs/ws": "^1.1.0",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "0.37.83",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "tslib": "2.6.2",
-        "undici": "5.27.2",
-        "ws": "8.14.2"
+        "undici": "6.13.0"
       },
       "engines": {
         "node": ">=16.11.0"
@@ -1868,14 +1858,11 @@
       "integrity": "sha512-QPmpqJvQqZ7rt2iVNzPrtQNSFs1zVuTuP+jzE3np7qytEUcfSKtAW8RTDslldeAwaJjVJa0UM3ps1uVddpEMqQ=="
     },
     "node_modules/undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
+      "integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/undici-types": {
@@ -2007,9 +1994,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/lodash": "^4.17.0",
     "a-calc": "^1.3.12",
     "axios": "^1.6.8",
-    "discord.js": "^14.14.1",
+    "discord.js": "^14.15.2",
     "dotenv": "^16.4.5",
     "lodash": "^4.17.21",
     "night-api": "^1.3.0"


### PR DESCRIPTION
Package **discord.js** updated from `^14.14.1` to `^14.15.2`. This removes some of the vulnerabilities found when `npm install`. I also noticed that minimum **node.js** version has always been `>=18`: https://github.com/42-Piscine-Batch-4/discordbot/blob/ec552837fd07842d2c2d516bb9e8128c2625b4f9/package-lock.json#L88 https://github.com/42-Piscine-Batch-4/discordbot/blob/ec552837fd07842d2c2d516bb9e8128c2625b4f9/package-lock.json#L123
maybe need to update `README`?
Be extremely careful merging this, I have tested and it seems like there is nothing wrong on my end but beware. Recommended commands to test:
```
/last
/fetch
```